### PR TITLE
Fix get code button working only one time

### DIFF
--- a/js/b2w-redirection-ajax.js
+++ b/js/b2w-redirection-ajax.js
@@ -40,7 +40,14 @@ function rt_start_config( nonce ){
 function generate_code( domain_name, curr_domain, nonce){
 
 	jQuery( '#code_here' ).show();
-	var response = jQuery( '#code_here' ).html();
+	let originalHtml = jQuery('#code_here').data('original-html');
+
+	if (!originalHtml) {
+		originalHtml = jQuery('#code_here').html();
+        jQuery('#code_here').data('original-html', originalHtml);
+	}
+
+	let response = originalHtml;
 	response = response.replace( /{{curr_domain}}/g, curr_domain );
 	response = response.replace( /{{domain_name}}/g, domain_name );
 	response = response.replace( /{{nonce}}/g, nonce );

--- a/js/b2w-redirection-ajax.js
+++ b/js/b2w-redirection-ajax.js
@@ -44,7 +44,7 @@ function generate_code( domain_name, curr_domain, nonce){
 
 	if (!originalHtml) {
 		originalHtml = jQuery('#code_here').html();
-        jQuery('#code_here').data('original-html', originalHtml);
+		jQuery('#code_here').data('original-html', originalHtml);
 	}
 
 	let response = originalHtml;


### PR DESCRIPTION
## Issue: Get code button only works for 1st time

This fixes: #42 

### Problem
Placeholders in the HTML template (e.g., `{{curr_domain}}`) were replaced only on first click of "Get Code". Subsequent attempts failed as placeholders were already replaced.

### Solution
- Store original HTML template with placeholders in a data attribute on first run.
- For each generation:
  - Retrieve stored template
  - Replace placeholders
  - Update HTML

This allows multiple code generations without page refresh, improving user experience.