### PR TITLE
Fix blog redirecting only first blogger blog in the list

### DIFF
--- a/b2w-redirection.php
+++ b/b2w-redirection.php
@@ -127,12 +127,9 @@ function rt_blogger_to_wordpress_redirection() {
 			wp_redirect( get_permalink( $wpurl[0][0] ) ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 
 			exit;
-		} else {
-			wp_safe_redirect( home_url(), 301 );
-			exit;
 		}
 	}
-
+	wp_safe_redirect( home_url(), 301 );
 }
 
 add_action( 'init', 'rt_blogger_to_wordpress_redirection' );


### PR DESCRIPTION
## Issue: Redirection Not Working if Multiple Blogger Blogs are added
This fixes: #41 

### Problem
The redirection function was only working for the first Blogger domain encountered in the list. Subsequent domains were not being checked, and the function was prematurely redirecting to the home page for all Blogger domains except the first.

### Solution
- Moved the `wp_safe_redirect( home_url(), 301 );` out of the main loop.
- Now if a matching Blogger domain was not found it wouldn't redirect to home page and exit the loop in the first iteration.

### Testing
1. Import at-least 2 blogger blogs and set redirection for them.
2. Check if the pages for all the blogger blogs are redirecting correctly and not only the first in the list is redirecting correctly.